### PR TITLE
Replace link in blog post

### DIFF
--- a/content/notes/dns.md
+++ b/content/notes/dns.md
@@ -204,7 +204,7 @@ listening on en0, link-type EN10MB (Ethernet), capture size 262144 bytes
 [rfc1034-space]: https://tools.ietf.org/html/rfc1034#section-3.1 "Domain space"
 [rfc7719]: https://tools.ietf.org/html/rfc7719 "DNS terminology"
 
-One single [SOA record](https://simpledns.plus/help/soa-records) (start of authority) exists for every given zone. As you can see here, my zone is `maelvls.dev.`.
+One single [SOA record](https://www.nslookup.io/learning/dns-record-types/soa/) (start of authority) exists for every given zone. As you can see here, my zone is `maelvls.dev.`.
 
 ## Playing with `k8s_gateway`
 


### PR DESCRIPTION
The current link is to the knowledge base of simple DNS plus (a Windows DNS server). However, that article isn't very informative, and contains instructions on how to use their software.